### PR TITLE
Fix build and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Its most basic design principle is that at the root of the react tree is the wri
     -   [`withOnPropChangedAnalytic`](#withonpropchangedanalytic)
 -   Hooks
     -   [`useAnalytics`](#useanalytics)
-    -   [`useAnalytic`](#useanalytic)
+    -   [`useAnalyticCallback`](#useanalyticcallback)
 -   Others
     -   [`AnalyticsProvider`](#analyticsprovider)
     -   [`analytics`](#analytics)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "rollup-plugin-typescript2": "^0.10.0",
         "rollup-plugin-uglify": "^3.0.0",
         "ts-jest": "^22.0.1",
-        "typescript": "^2.6.2"
+        "typescript": "^3.9.3"
     },
     "dependencies": {
         "shisell": "^1.1.0"

--- a/src/hoc/with-analytic-on-event.tsx
+++ b/src/hoc/with-analytic-on-event.tsx
@@ -38,7 +38,7 @@ const withAnalyticOnEventPropTypes = {
 };
 
 const getPossibleFunctionValue = <Event, Value>(e: Event, f: ((e: Event) => Value) | Value | undefined) =>
-    typeof f === 'function' ? f(e) : f;
+    typeof f === 'function' ? (f as Function)(e) : f;
 const isBoolean = (val: any) => typeof val === 'boolean';
 
 type AnalyticOnEventProps = WithAnalyticsProps & {

--- a/src/hoc/with-analytics.tsx
+++ b/src/hoc/with-analytics.tsx
@@ -12,7 +12,7 @@ export function withAnalytics<TProps extends WithAnalyticsProps>(BaseComponent: 
         Pick<TProps, Exclude<keyof TProps, keyof WithAnalyticsProps>>
     > = props => (
         <ShisellContext.Consumer>
-            {analytics => <BaseComponent {...props} analytics={analytics} />}
+            {analytics => <BaseComponent {...(props as TProps)} analytics={analytics} />}
         </ShisellContext.Consumer>
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5290,10 +5290,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^2.6.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 uglify-es@^3.3.7:
   version "3.3.9"


### PR DESCRIPTION
Fixes `yarn build` which was broken in PR #32 because of a typescript error. I had my vscode set to latest typescript but this project was using version 2.6.2, so it didn't show an error. This PR updates the project to ts 3.9.3 to fix the error.

Yarn build and test output:

```
amp~/dev/react-shisell: yarn build
yarn run v1.22.4
$ rimraf dist && rollup -c

src/index.ts → dist/react-shisell.es.js, dist/react-shisell.cjs.js...
created dist/react-shisell.es.js, dist/react-shisell.cjs.js in 2.7s
✨  Done in 3.36s.
amp~/dev/react-shisell: yarn test
yarn run v1.22.4
$ jest --config jest.config.json
 PASS  src/hoc/with-analytic-on-event.spec.tsx
 PASS  src/hoc/enrich-analytics.spec.tsx
 PASS  src/hooks/use-analytics.spec.tsx
 PASS  src/hoc/with-analytic-on-view.spec.tsx
 PASS  src/hooks/use-analytic-callback.spec.tsx
 PASS  src/hoc/with-on-prop-changed-analytic.spec.tsx
 PASS  src/hooks/use-event-analytic.spec.tsx
 PASS  src/hoc/with-analytics.spec.tsx

Test Suites: 8 passed, 8 total
Tests:       28 passed, 28 total
Snapshots:   0 total
Time:        2.3s
Ran all test suites.
✨  Done in 3.09s.
amp~/dev/react-shisell: 
```